### PR TITLE
Add Playwright MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "@playwright/mcp@latest"
+      ],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a project-scoped `.mcp.json` registering the [Playwright MCP](https://github.com/microsoft/playwright-mcp) server, making browser-automation tooling available to anyone using Claude Code in this repo.

```json
{
  "mcpServers": {
    "playwright": {
      "type": "stdio",
      "command": "npx",
      "args": ["@playwright/mcp@latest"],
      "env": {}
    }
  }
}
```

## Notes

- Project-scoped MCP servers require **per-user approval** on first launch of `claude` in the repo (security prompt) before their tools activate.
- Playwright MCP downloads Chromium on first run; on WSL/Linux, `npx playwright install-deps` may be needed for system libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)