### PR TITLE
Name ci-test job "CI" for a searchable status check

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   check:
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Add an explicit `name: CI` to the `ci-test` workflow's `check` job so it reports as a stable, searchable status check context.

## Why
Without an explicit job `name`, GitHub derives the status-check context from the job key (`check`) — generic and awkward to find/reference in branch protection rules. Naming it `CI` gives a clear context to require.

## Follow-up
After merge, the workflow runs once with the new name; then search `CI` in the branch ruleset and select it as a required status check. Any rule requiring the old `check` context will need re-selecting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)