### PR TITLE
Bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "svelte-check": "^4.1.5",
     "tailwindcss": "^4.1.1",
     "tslib": "^2.5.0",
-    "typescript": "^5.8.2",
+    "typescript": "^6.0.3",
     "vite": "^8.1.4"
   },
   "packageManager": "pnpm@11.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 5.56.4
       svelte-check:
         specifier: ^4.1.5
-        version: 4.7.2(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3)
+        version: 4.7.2(picomatch@4.0.5)(svelte@5.56.4)(typescript@6.0.3)
       tailwindcss:
         specifier: ^4.1.1
         version: 4.3.2
@@ -37,8 +37,8 @@ importers:
         specifier: ^2.5.0
         version: 2.8.1
       typescript:
-        specifier: ^5.8.2
-        version: 5.9.3
+        specifier: ^6.0.3
+        version: 6.0.3
       vite:
         specifier: ^8.1.4
         version: 8.1.4(jiti@2.7.0)
@@ -525,8 +525,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -921,7 +921,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  svelte-check@4.7.2(picomatch@4.0.5)(svelte@5.56.4)(typescript@5.9.3):
+  svelte-check@4.7.2(picomatch@4.0.5)(svelte@5.56.4)(typescript@6.0.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@sveltejs/load-config': 0.2.0
@@ -930,7 +930,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.56.4
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - picomatch
 
@@ -968,7 +968,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   vite@8.1.4(jiti@2.7.0):
     dependencies:


### PR DESCRIPTION
Bumps the `typescript` devDependency from 5.9.3 to 6.0.3.

## Why 6.0.3 and not 7.x

TypeScript 6.0.3 is the **last JS-based TS release**. TypeScript 7.0 is the native/Go compiler rewrite, which is not yet compatible with svelte-check (the project's only CI gate). Staying on 6.0.3 gets us the newest supported compiler while avoiding that breakage.

## Verification

- The declared range was `^5.8.2` (resolved to 5.9.3 in the lockfile); updated to `^6.0.3`, preserving the caret prefix.
- `pnpm install` regenerated `pnpm-lock.yaml` (typescript now resolves to 6.0.3). Only `package.json` and `pnpm-lock.yaml` changed.
- `pnpm check` (svelte-check 4.7.2) passes locally: **122 files, 0 errors, 0 warnings**. No `moduleResolution=node10` / `ignoreDeprecations` deprecation warning surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)