### PR TITLE
Ignore Claude local files and enforce pnpm

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,2 +1,3 @@
 worktrees/
 *.local.*
+

--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,2 @@
+worktrees/
+*.local.*

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "preinstall": "npx only-allow pnpm",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "prepare": "husky"


### PR DESCRIPTION
## Summary
- Add `.claude/.gitignore` to exclude worktrees and local-only files from version control
- Add a `preinstall` script enforcing pnpm via `only-allow`, matching the `packageManager` pin

## Test plan
- [x] `pnpm check` passes (pre-commit hook)