### PR TITLE
Switch Dependabot checks from daily to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@ updates:
     reviewers:
       - "djkotowski"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     versioning-strategy: "increase-if-necessary"
   - package-ecosystem: "github-actions"
     directory: "/"
     reviewers:
       - "djkotowski"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Change both the npm and github-actions Dependabot update schedules from daily to weekly to reduce PR noise.

## Test plan
- [x] `pnpm check` passes (ran via pre-commit hook)
- [x] Reviewed `.github/dependabot.yml` diff for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)