### PR TITLE
Fix Pages deploy concurrency and tag successful deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,8 @@ on:
     branches:
       - 'main'
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,11 +33,21 @@ jobs:
     permissions:
       pages: write
       id-token: write
+      contents: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+      - name: Tag deploy
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          tag="deploy-$(date +%Y-%m-%d)-${GITHUB_SHA::7}"
+          git tag "$tag"
+          git push origin "$tag"


### PR DESCRIPTION
## Summary
- Switch deploy concurrency to GitHub's recommended `group: pages, cancel-in-progress: false` pattern, so a superseded run is skipped before starting instead of killing an in-progress `deploy-pages` call mid-flight (which can leave the Pages deployment stuck).
- Tag each successfully deployed commit as `deploy-YYYY-MM-DD-<short-sha>` right after `deploy-pages` succeeds, giving a lightweight history of what was actually deployed and when.