### PR TITLE
Gate Pages deploy on ci-test passing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,22 @@
 name: deploy
-run-name: "${{ github.actor }} is deploying ${{ github.sha }}"
+run-name: "${{ github.actor }} is deploying ${{ github.event.workflow_run.head_sha }}"
 on:
-  push:
-    branches:
-      - 'main'
+  workflow_run:
+    workflows: ['ci-test']
+    types: [completed]
+    branches: ['main']
 concurrency:
   group: pages
   cancel-in-progress: false
 jobs:
   build:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v5
       - name: Setup Node.js
@@ -41,6 +45,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
@@ -48,6 +54,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          tag="deploy-$(date +%Y-%m-%d)-${GITHUB_SHA::7}"
-          git tag "$tag"
+          sha="${{ github.event.workflow_run.head_sha }}"
+          tag="deploy-$(date +%Y-%m-%d)-${sha::7}"
+          git tag "$tag" "$sha"
           git push origin "$tag"


### PR DESCRIPTION
## Summary
- deploy.yml now triggers via workflow_run on ci-test completion (filtered to branch main), instead of triggering directly on push to main
- The build job is skipped unless the triggering ci-test run concluded success, so a merge that breaks pnpm check no longer publishes to Pages
- Both checkout steps and the deploy tag step now explicitly use the workflow_run head_sha, since workflow_run does not automatically check out the triggering commit and GITHUB_SHA would otherwise point at the wrong ref

## Why
The PR check (ci-test on pull_request) does not protect against a merge commit itself breaking the app (e.g. a merge conflict resolution, or a branch protection bypass). Chaining deploy off ci ensures the push-to-main run of ci-test has to pass before anything gets published.

## Test plan
- [ ] Confirm the ci-test workflow_run event fires deploy after a push to main
- [ ] Confirm deploy is skipped when ci-test fails on main (e.g. by temporarily breaking pnpm check on a throwaway commit)
- [ ] Confirm the deployed commit and pushed tag match the head_sha of the successful ci-test run